### PR TITLE
Fix 6 issues

### DIFF
--- a/bitshares-pts.php
+++ b/bitshares-pts.php
@@ -86,15 +86,15 @@
 									<td id="vol-val">0</td>
 								</tr>
 							</table>
-							<small>* USD is calculated from MtGox BTC price and Exchange PTS price.</small>
+							<small>* USD is calculated from the Mt.Gox BTC price and the PTS price on the BTER and Cryptsy exchanges.</small>
 
               <h3> Exchanges</h3>
 
                       <p>Exchanges are the trading websites where you can buy or sell PTS. Be careful not to place large sums of PTS on exchanges without adequate security measures, such as a good password and 2-factor authentication.</p>
                       <ul style="list-style-type: circle;">
-                          <li><a href="https://bter.com/">Bter Exchange</a></li>
+                          <li><a href="https://bter.com/">BTER Exchange</a></li>
                           <li><a href="https://www.cryptsy.com/">Cryptsy Exchange</a></li>
-                          <li><a href="http://www.btc38.com/">Btc38 Exchange</a></li>
+                          <li><a href="http://www.btc38.com/">BTC38 Exchange</a></li>
                           <li><a href="https://peatio.com/">Peatio Exchange</a></li>
                       </ul>
 
@@ -102,7 +102,7 @@
                       <p>To learn more about PTS, explore the following resources:</p>
                       <ul style="list-style-type: circle;">
                           <li><a href="http://btsblock.com/chain/ProtoShares">Blockchain explorer - View transactions by PTS address</a></li>
-                          <li><a href="https://coinplorer.com/PTS">PTS Coin Information - Current PTS Statistics</a></li>
+                          <li><a href="https://coinplorer.com/PTS">PTS Coin information - Current PTS statistics</a></li>
                           <li><a href="https://bitsharestalk.org/index.php?board=1.0">Official PTS forum</a></li>
                           <li><a href="http://www.reddit.com/r/protoshare">Sub-Reddit for PTS</a></li>
                       </ul>


### PR DESCRIPTION
4) capital letters missing or unneeded: BTC38, BTER, statistics, information
1) period missing: Mt.Gox 
1) Sentence rewritten: USD is calculated from the Mt.Gox BTC price and the PTS price on the BTER and Cryptsy exchanges
Total 6.
