### PR TITLE
Get rid of MtGox Data as BTC price source

### DIFF
--- a/assets/js/pts.prices.js
+++ b/assets/js/pts.prices.js
@@ -87,13 +87,15 @@ function updatePrices(){
 
 	var exchange = getCurrentExchange();
 
-	$.getJSON( "getprice.php?exchange=MtGox", function( gox_data ) {
+	$.getJSON( "getprice.php?exchange=blockchain", function( blockchain_data ) {
 		$.getJSON( "getprice.php?exchange=" + exchange, function( data ) {
+
+			var currPrice = parseFloat(blockchain_data.USD.last);
 
 			if(exchange === "Bter"){
 
-				// Calculate the USD value based on MtGox last price and exchange BTC/PTS last price = (USD/BTC) / (BTC/PTS) 
-				var usd = (parseFloat(gox_data.data.last.value) * parseFloat(data.last)).toFixed(2);
+				// Calculate the USD value based on blockchain.info last price and exchange BTC/PTS last price = (USD/BTC) / (BTC/PTS) 
+				var usd = (currPrice * parseFloat(data.last)).toFixed(2);
 
 				$("#price-usd").empty().append("$" + usd);	
 				$("#price-val").empty().append(data.last);	
@@ -103,8 +105,8 @@ function updatePrices(){
 			}
 			else if (exchange === "Cryptsy"){
 				
-				// Calculate the USD value based on MtGox last price and exchange BTC/PTS last price = (USD/BTC) / (BTC/PTS) 
-				var usd = (parseFloat(gox_data.data.last.value) * parseFloat(data.return.markets.PTS.lasttradeprice)).toFixed(2);
+				// Calculate the USD value based on blockchain.info last price and exchange BTC/PTS last price = (USD/BTC) / (BTC/PTS) 
+				var usd = (currPrice * parseFloat(data.return.markets.PTS.lasttradeprice)).toFixed(2);
 
 				$("#price-usd").empty().append("$" + usd);	
 				$("#price-val").empty().append(parseFloat(data.return.markets.PTS.lasttradeprice).toFixed(4));	

--- a/bitshares-pts.php
+++ b/bitshares-pts.php
@@ -86,7 +86,7 @@
 									<td id="vol-val">0</td>
 								</tr>
 							</table>
-							<small>* USD is calculated from MtGox BTC price and Exchange PTS price.</small>
+							<small>* USD is calculated from Blockchain.info reported market price and Exchange PTS price.</small>
 
               <h3> Exchanges</h3>
 

--- a/bitshares.php
+++ b/bitshares.php
@@ -134,7 +134,7 @@
 							  -->
 							<table class="table table-bordered">
 								<tr>
-									<th>Price (USD)*</th>
+									<th>Price (USD)</th>
 									<th>Price (BTC/PTS)</th>
 									<th>High (BTC/PTS)</th>
 									<th>Low (BTC/PTS)</th>

--- a/bitsharesx.php
+++ b/bitsharesx.php
@@ -173,7 +173,7 @@
 							  -->
 							<table class="table table-bordered">
 								<tr>
-									<th>Price (USD)*</th>
+									<th>Price (USD)</th>
 									<th>Price (BTC/PTS)</th>
 									<th>High (BTC/PTS)</th>
 									<th>Low (BTC/PTS)</th>

--- a/getprice.php
+++ b/getprice.php
@@ -23,5 +23,10 @@ elseif ($_REQUEST['exchange'] == 'MtGox')
 	$api_val = file_get_contents('http://data.mtgox.com/api/2/BTCUSD/money/ticker');	
 	echo $api_val;	
 }
+elseif ($_REQUEST['exchange'] == 'blockchain')
+{
+	$api_val = file_get_contents('https://blockchain.info/ticker');	
+	echo $api_val;	
+}
 
 ?>


### PR DESCRIPTION
I propose we use the BTC market price reported from blockchain.info instead of MtGox for the PTS prices we calculate.  

https://blockchain.info/api/exchange_rates_api
